### PR TITLE
Support custom serializers

### DIFF
--- a/Sources/Alamofire+Promise.swift
+++ b/Sources/Alamofire+Promise.swift
@@ -142,7 +142,7 @@ public enum PMKAlamofireOptions {
 
 
 public struct PMKAlamofireDataResponse {
-    fileprivate init<T>(_ rawrsp: Alamofire.DataResponse<T>) {
+    public init<T>(_ rawrsp: Alamofire.DataResponse<T>) {
         request = rawrsp.request
         response = rawrsp.response
         data = rawrsp.data


### PR DESCRIPTION
Thank you so much for this useful library! I can hardly believe I've been trying to get by using completion handlers for so long. This is going to clean up my code _so_ much.

Alamofire supports custom response serializers:

* https://littlebitesofcocoa.com/94-custom-alamofire-response-serializers
* https://github.com/Alamofire/Alamofire/blob/c8ffe77f0b7bcdbacdbbc6a13d5de18e53c08ae4/Documentation/AdvancedUsage.md#creating-a-custom-response-serializer

I have a use case where I've written one of these, and would like to use it with PromiseKit. When I adapt code form here and add an extension to support my custom serializer, I'm unable to initialize the PMKAlamofireDataResponse because of the protection level. This is the error:

```
'PMKAlamofireDataResponse' initializer is inaccessible due to 'fileprivate' protection level
```

Would it make sense to support this use case?