### PR TITLE
'Cancel' for PromiseKit option 2

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,4 +1,5 @@
 github "mxcl/PromiseKit" ~> 6.0
 github "Alamofire/Alamofire" ~> 4.0
+
 #github "PromiseKit/Cancel" ~> 1.0
 github "dougzilla32/Cancel" ~> 1.0

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,4 @@
 github "mxcl/PromiseKit" ~> 6.0
 github "Alamofire/Alamofire" ~> 4.0
+#github "PromiseKit/Cancel" ~> 1.0
+github "dougzilla32/Cancel" ~> 1.0

--- a/Cartfile
+++ b/Cartfile
@@ -1,5 +1,5 @@
-github "mxcl/PromiseKit" ~> 6.0
+#github "mxcl/PromiseKit" ~> 6.0
+github "dougzilla32/PromiseKit" "PMKCancel"
 github "Alamofire/Alamofire" ~> 4.0
-
 #github "PromiseKit/Cancel" ~> 1.0
 github "dougzilla32/Cancel" ~> 1.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
 github "Alamofire/Alamofire" "4.7.3"
 github "AliSoftware/OHHTTPStubs" "6.1.0"
 github "dougzilla32/Cancel" "1.0.0"
-github "mxcl/PromiseKit" "6.3.4"
+github "dougzilla32/PromiseKit" "a0217bd7b69af68237dcdeee0197e63259b9d445"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,4 @@
-github "Alamofire/Alamofire" "4.7.2"
+github "Alamofire/Alamofire" "4.7.3"
 github "AliSoftware/OHHTTPStubs" "6.1.0"
-github "mxcl/PromiseKit" "6.3.3"
+github "dougzilla32/Cancel" "1.0.0"
+github "mxcl/PromiseKit" "6.3.4"

--- a/PMKAlamofire.xcodeproj/project.pbxproj
+++ b/PMKAlamofire.xcodeproj/project.pbxproj
@@ -188,6 +188,7 @@
 				PromiseKit,
 				OHHTTPStubs,
 				Alamofire,
+				PMKCancel,
 			);
 			name = "Embed Carthage Frameworks";
 			outputPaths = (

--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,9 @@ let package = Package(
     name: "PMKAlamofire",
     dependencies: [
         .Package(url: "https://github.com/mxcl/PromiseKit.git", majorVersion: 4),
-        .Package(url: "https://github.com/Alamofire/Alamofire.git", majorVersion: 4)
+        .Package(url: "https://github.com/Alamofire/Alamofire.git", majorVersion: 4),
+//      .Package(url: "https://github.com/PromiseKit/Cancel.git", majorVersion: 1),
+        .Package(url: "https://github.com/dougzilla32/Cancel.git", majorVersion: 1)
     ],
     exclude: ["Tests"]
 )

--- a/Sources/Alamofire+Promise.swift
+++ b/Sources/Alamofire+Promise.swift
@@ -1,6 +1,7 @@
 @_exported import Alamofire
 import Foundation
 #if !PMKCocoaPods
+import PMKCancel
 import PromiseKit
 #endif
 
@@ -186,4 +187,64 @@ public struct PMKAlamofireDataResponse {
 
     /// The timeline of the complete lifecycle of the request.
     public let timeline: Timeline
+}
+
+//////////////////////////////////////////////////////////// Cancellation
+
+extension Request: CancellableTask {
+    /// `true` if the Alamofire request was successfully cancelled, `false` otherwise
+    public var isCancelled: Bool {
+        return task?.state == .canceling
+    }
+}
+
+extension Alamofire.DataRequest {
+    /// Wraps Alamofire.Response from Alamofire.response(queue:) as CancellablePromise<(Foundation.URLRequest, Foundation.HTTPURLResponse, Foundation.Data)>
+    public func responseCC(_: PMKNamespacer, queue: DispatchQueue? = nil) -> CancellablePromise<(URLRequest, HTTPURLResponse, Data)> {
+        return CancellablePromise(task: self, self.response(.promise, queue: queue))
+    }
+    
+    /// Wraps Alamofire.DataResponse from Alamofire.responseData(queue:) as CancellablePromise<(Foundation.Data, PromiseKit.PMKAlamofireDataResponse)>
+    public func responseDataCC(queue: DispatchQueue? = nil) -> CancellablePromise<(data: Data, response: PMKAlamofireDataResponse)> {
+        return CancellablePromise(task: self, self.responseData(queue: queue))
+    }
+    
+    /// Wraps the response from Alamofire.responseString(queue:) as CancellablePromise<(String, PromiseKit.PMKAlamofireDataResponse)>.  Uses the default encoding to decode the string data.
+    public func responseStringCC(queue: DispatchQueue? = nil) -> CancellablePromise<(string: String, response: PMKAlamofireDataResponse)> {
+        return CancellablePromise(task: self, self.responseString(queue: queue))
+    }
+    
+    /// Wraps the response from Alamofire.responseJSON(queue:options:) as CancellablePromise<(Any, PromiseKit.PMKAlamofireDataResponse)>.  By default, the JSON decoder allows fragments, therefore 'Any' can be any standard JSON type (NSArray, NSDictionary, NSString, NSNumber, or NSNull).  If the received JSON is not a fragment then 'Any' will be either an NSArray or NSDictionary.
+    public func responseJSONCC(queue: DispatchQueue? = nil, options: JSONSerialization.ReadingOptions = .allowFragments) -> CancellablePromise<(json: Any, response: PMKAlamofireDataResponse)> {
+        return CancellablePromise(task: self, self.responseJSON(queue: queue, options: options))
+    }
+    
+    /// Wraps the response from Alamofire.responsePropertyList(queue:options:) as CancellablePromise<(Any, PromiseKit.PMKAlamofireDataResponse)>.  Uses Foundation.PropertyListSerialization to deserialize the property list.  'Any' is an NSArray or NSDictionary containing only the types NSData, NSString, NSArray, NSDictionary, NSDate, and NSNumber.
+    public func responsePropertyListCC(queue: DispatchQueue? = nil, options: PropertyListSerialization.ReadOptions = PropertyListSerialization.ReadOptions()) -> CancellablePromise<(plist: Any, response: PMKAlamofireDataResponse)> {
+        return CancellablePromise(task: self, self.responsePropertyList(queue: queue, options: options))
+    }
+    
+    #if swift(>=3.2)
+    /// Wraps the response from Alamofire.responseDecodable(queue:) as CancellablePromise<Decodable>.  The Decodable is used to decode the incoming JSON data.
+    public func responseDecodableCC<T: Decodable>(queue: DispatchQueue? = nil, decoder: JSONDecoder = JSONDecoder()) -> CancellablePromise<T> {
+        return CancellablePromise(task: self, self.responseDecodable(queue: queue, decoder: decoder))
+    }
+    
+    /// Wraps the response from Alamofire.responseDecodable() as CancellablePromise<(Decodable)>.  The Decodable is used to decode the incoming JSON data.
+    public func responseDecodableCC<T: Decodable>(_ type: T.Type, queue: DispatchQueue? = nil, decoder: JSONDecoder = JSONDecoder()) -> CancellablePromise<T> {
+        return CancellablePromise(task: self, self.responseDecodable(type, queue: queue, decoder: decoder))
+    }
+    #endif
+}
+
+extension Alamofire.DownloadRequest {
+    /// Wraps Alamofire.Reponse.DefaultDownloadResponse from Alamofire.DownloadRequest.response(queue:) as CancellablePromise<Alamofire.Reponse.DefaultDownloadResponse>
+    public func responseCC(_: PMKNamespacer, queue: DispatchQueue? = nil) -> CancellablePromise<DefaultDownloadResponse> {
+        return CancellablePromise(task: self, self.response(.promise, queue: queue))
+    }
+    
+    /// Wraps Alamofire.Reponse.DownloadResponse<Data> from Alamofire.DownloadRequest.responseData(queue:) as CancellablePromise<Alamofire.Reponse.DownloadResponse<Data>>
+    public func responseDataCC(queue: DispatchQueue? = nil) -> CancellablePromise<DownloadResponse<Data>> {
+        return CancellablePromise(task: self, self.responseData(queue: queue))
+    }
 }

--- a/Tests/TestAlamofire.swift
+++ b/Tests/TestAlamofire.swift
@@ -1,3 +1,4 @@
+import PMKCancel
 import PMKAlamofire
 import OHHTTPStubs
 import PromiseKit
@@ -71,4 +72,76 @@ class AlamofireTests: XCTestCase {
         
     }
 #endif
+}
+
+//////////////////////////////////////////////////////////// Cancellation
+
+extension AlamofireTests {
+    func testCancel() {
+        let json: NSDictionary = ["key1": "value1", "key2": ["value2A", "value2B"]]
+        
+        OHHTTPStubs.stubRequests(passingTest: { $0.url!.host == "example.com" }) { _ in
+            return OHHTTPStubsResponse(jsonObject: json, statusCode: 200, headers: nil)
+        }
+        
+        let ex = expectation(description: "")
+        
+        firstly {
+            Alamofire.request("http://example.com", method: .get).responseJSONCC()
+        }.done { _ in
+            XCTFail("failed to cancel request")
+        }.catch(policy: .allErrors) { error in
+            error.isCancelled ? ex.fulfill() : XCTFail("Error: \(error)")
+        }.cancel()
+        
+        waitForExpectations(timeout: 1)
+    }
+
+#if swift(>=3.2)
+    func testCancelDecodable1() {
+        
+        func getFixture() -> CancellablePromise<Fixture> {
+            return Alamofire.request("http://example.com", method: .get).responseDecodableCC(queue: nil)
+        }
+        
+        let json: NSDictionary = ["key1": "value1", "key2": ["value2A", "value2B"]]
+        
+        OHHTTPStubs.stubRequests(passingTest: { $0.url!.host == "example.com" }) { _ in
+            return OHHTTPStubsResponse(jsonObject: json, statusCode: 200, headers: nil)
+        }
+        
+        let ex = expectation(description: "")
+        
+        getFixture().done { fixture in
+            XCTAssert(fixture.key1 == "value1", "Value1 found")
+            XCTFail("failed to cancel request")
+        }.catch(policy: .allErrors) { error in
+            error.isCancelled ? ex.fulfill() : XCTFail("Error: \(error)")
+        }.cancel()
+        
+        waitForExpectations(timeout: 1)
+    }
+    
+    func testCancelDecodable2() {
+        let json: NSDictionary = ["key1": "value1", "key2": ["value2A", "value2B"]]
+        
+        OHHTTPStubs.stubRequests(passingTest: { $0.url!.host == "example.com" }) { _ in
+            return OHHTTPStubsResponse(jsonObject: json, statusCode: 200, headers: nil)
+        }
+        
+        let ex = expectation(description: "")
+        
+        firstly {
+            Alamofire.request("http://example.com", method: .get).responseDecodableCC(Fixture.self)
+        }.done { fixture in
+            XCTAssert(fixture.key1 == "value1", "Value1 found")
+            XCTFail("failed to cancel request")
+        }.catch(policy: .allErrors) { error in
+            error.isCancelled ? ex.fulfill() : XCTFail("Error: \(error)")
+        }.cancel()
+        
+        waitForExpectations(timeout: 1)
+        
+    }
+    #endif
 }


### PR DESCRIPTION
These are the diffs for option 2 of [Proposal for PromiseKit cancellation support #896](https://github.com/mxcl/PromiseKit/issues/896).  With option 2 the new cancellation code goes in a new PromiseKit extension called PMKCancel.

The repository for the new PMKCancel extension is currently hosted at https://github.com/dougzilla32/Cancel, but would be moved to https://github.com/PromiseKit/Cancel if option 2 is accepted.

There repositories with pull requests for option 2 are:

Repositories  |
------------- |
[mxcl/PromiseKit](https://github.com/mxcl/PromiseKit) |
[PromiseKit/Alamofire-](https://github.com/PromiseKit/Alamofire-) |
[PromiseKit/Bolts](https://github.com/PromiseKit/Bolts) |
[dougzilla32/Cancel](https://github.com/dougzilla32/Cancel) |
[PromiseKit/CoreLocation](https://github.com/PromiseKit/CoreLocation) |
[PromiseKit/Foundation](https://github.com/PromiseKit/Foundation) |
[PromiseKit/MapKit](https://github.com/PromiseKit/MapKit) |
[PromiseKit/OMGHTTPURLRQ-](https://github.com/PromiseKit/OMGHTTPURLRQ-) |
[PromiseKit/StoreKit](https://github.com/PromiseKit/StoreKit) |
[PromiseKit/SystemConfiguration](https://github.com/PromiseKit/SystemConfiguration) |
[PromiseKit/UIKit](https://github.com/PromiseKit/UIKit) |
