### PR TITLE
fix Swift Package Manager after update to PromiseKit 6

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,7 @@ import PackageDescription
 let package = Package(
     name: "PMKAlamofire",
     dependencies: [
-        .Package(url: "https://github.com/mxcl/PromiseKit.git", majorVersion: 4),
+        .Package(url: "https://github.com/mxcl/PromiseKit.git", majorVersion: 6),
         .Package(url: "https://github.com/Alamofire/Alamofire.git", majorVersion: 4)
     ],
     exclude: ["Tests"]


### PR DESCRIPTION
Version 3.0.0 of this module [updated to PromiseKit 6][update-commit], but the [Package.swift][package-swift] file was never updated. As a result, this module appears to be completely unusable with Swift Package Manager:

- If the repository is listed as a dependency without an explicit dependency on PromiseKit 6, SwiftPM will try to use PromiseKit 4, resulting in compilation errors.
- If the repository is listed as a dependency alongside an explicit peer dependency on PromiseKit 6, SwiftPM will try to use both versions, resulting in an error about how the "dependency graph is unresolvable."

With that being said, I'm not very experienced with Swift Package Manager, so I could definitely be missing something. It just seems like the version number in the SwiftPM package file should match the one in the [Cartfile][cartfile].

[update-commit]: https://github.com/PromiseKit/Alamofire-/commit/b06f83c3a0fa69b34aae07fc24039f30c396b9df
[cartfile]: https://github.com/PromiseKit/Alamofire-/blob/3.0.0/Cartfile
[package-swift]: https://github.com/PromiseKit/Alamofire-/blob/3.0.0/Package.swift