### PR TITLE
fix PMKAlamofire imports compatibility with CocoaPods

### DIFF
--- a/Sources/Alamofire+Promise.swift
+++ b/Sources/Alamofire+Promise.swift
@@ -1,4 +1,4 @@
-@_exported import Alamofire
+import Alamofire
 import Foundation
 #if !PMKCocoaPods
 import PromiseKit

--- a/Sources/Alamofire+Promise.swift
+++ b/Sources/Alamofire+Promise.swift
@@ -1,6 +1,6 @@
+@_exported import Alamofire
 import Foundation
 #if !PMKCocoaPods
-import Alamofire
 import PromiseKit
 #endif
 


### PR DESCRIPTION
Can't compile project with PMKAlamofire installed with CocoaPods due to recent changes in imports section. This PR restores previous state as it was in PMKAlamofire v5.0.0.

Upd: modified import to remove export